### PR TITLE
undo 2 previous commits that apparently weren't tested with solr.thum…

### DIFF
--- a/djangocms_unitegallery/cms_plugins.py
+++ b/djangocms_unitegallery/cms_plugins.py
@@ -21,10 +21,9 @@ class GalleryPlugin(CMSPluginBase):
     inlines = [PhotoInline, ]
 
     def get_render_template(self, context, instance, placeholder):
-        try:
-            import easy_thumbnails
+        if CONFIG.get('USE_EASYTHUMBNAILS', False):
             return 'djangocms_unitegallery/easythumb-gallery.html'
-        except ImportError:
+        else:
             return 'djangocms_unitegallery/gallery.html'
 
     def render(self, context, instance, placeholder):

--- a/djangocms_unitegallery/templates/djangocms_unitegallery/gallery.html
+++ b/djangocms_unitegallery/templates/djangocms_unitegallery/gallery.html
@@ -2,7 +2,7 @@
 <div id="gallery_{{ gallery.pk }}" style="display:none;" class="unitegallery{% if gallery.custom_classes %} {{ gallery.custom_classes }}{% endif %}">
 {% for photo in gallery.photos.all %}
   {% if CONFIG.THUMBNAIL_ENABLED %}
-    {% thumbnail photo.image photo.get_thumbnail_size crop="center" as im %}{% include "djangocms_unitegallery/_photo.html" %}
+    {% thumbnail photo.image photo.get_thumbnail_size crop="center" as im %}{% include "djangocms_unitegallery/_photo.html" %}{% endthumbnail %}
   {% else %}
     {% with photo.image as im %}{% include "djangocms_unitegallery/_photo.html" %}{% endwith %}
   {% endif %}


### PR DESCRIPTION
undo 2 previous commits that apparently weren't tested with solr.thumbnail (the default); solr.thumbnail and easy_thumbnails can both be installed, and explicitly using one of them for the unitegallery via the config setting is to be preferred. Above, the gallery.html template is for solr.thumbnails, hence needs a {% endthumbnail %} template tag for closing
